### PR TITLE
Comment admin

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -46,14 +46,14 @@ Comments = {
   _mediaService: mediaService
 };
 
-if (Meteor.isClient) {
-  Comments.ui = (function () {
+Comments.ui = (function () {
     let config = {
       limit: 5,
       loadMoreCount: 10,
       template: 'semantic-ui',
       defaultAvatar:'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png',
-      markdown: false
+      markdown: false,
+      isModerator: (userId) => false
     };
     Avatar.setOptions({
       defaultImageUrl: 'http://s3.amazonaws.com/37assets/svn/765-default-avatar.png'
@@ -67,14 +67,20 @@ if (Meteor.isClient) {
 
         config = _.extend(config, newConfig);
       },
-      setContent: (content) => Comments.session.set('content', content),
+      setContent: function (content) {
+          if(Meteor.isClient){
+            Comments.session.set('content', content);
+          }
+      },
       callIfLoggedIn: function (action, cb) {
-        if (!userService.getUserId()) {
-          Comments.session.set('loginAction', action);
-        } else {
-          return cb();
+        if(Meteor.isClient) {
+          if (!userService.getUserId()) {
+            Comments.session.set('loginAction', action);
+          } else {
+            return cb();
+          }
         }
       }
     };
   })();
-}
+

--- a/lib/collections/methods/comments.js
+++ b/lib/collections/methods/comments.js
@@ -102,8 +102,12 @@ Meteor.methods({
 
     userService.verifyAnonUserData(anonUserData);
     const userId = this.userId || anonUserData._id;
-
-    CommentsCollection.remove({ _id: documentId, userId });
+    if(Comments.ui.config().isModerator(userId)){
+      CommentsCollection.remove({ _id: documentId});
+    }
+    else{
+      CommentsCollection.remove({ _id: documentId}, userId);
+    }
   },
   'comments/like': function (documentId, anonUserData) {
     check (documentId, String);
@@ -228,7 +232,7 @@ Meteor.methods({
     }
 
     modifyNestedReplies(doc.replies, docScope.position, function (replies, index) {
-      if (replies[index].userId === userId) {
+      if (replies[index].userId === userId || Comments.ui.config().isModerator(userId)) {
         replies.splice(index, 1);
       }
     });

--- a/lib/components/commentsBox/commentsBox.less
+++ b/lib/components/commentsBox/commentsBox.less
@@ -64,7 +64,7 @@
     }
 
     .img-avatar {
-        min-width: 50px;
-        min-height: 50px;
+        width: 50px;
+        height: 50px;
     }
 }

--- a/lib/components/commentsBox/commentsBox.less
+++ b/lib/components/commentsBox/commentsBox.less
@@ -66,5 +66,7 @@
     .img-avatar {
         width: 50px;
         height: 50px;
+        min-width: 50px;
+        min-height: 50px;
     }
 }

--- a/lib/components/commentsSingleComment/commentsSingleComment.js
+++ b/lib/components/commentsSingleComment/commentsSingleComment.js
@@ -3,7 +3,7 @@ Template.commentsSingleComment.helpers(_.extend(defaultCommentHelpers, {
     return this.likes.indexOf(userService.getUserId()) > -1;
   },
   isOwnComment() {
-    return this.userId === userService.getUserId();
+    return (this.userId === userService.getUserId() || Comments.ui.config().isModerator(userService.getUserId()));
   },
   addReply() {
     const id = this._id || this.replyId;


### PR DESCRIPTION
I wanted to add a feature to comments-ui that allowed administrators the right to remove offensive/inappropriate comments made by other users.  To do this I did the following:
1.  Refactored Comments.ui.config() to only require Meteor.isClient for the functions that dealt with the front end.  It seemed to me the original intention was that the config object could also configure back-end functionality.  My modification required this as we need access to the new isModerator() config function both on the front end (isOwnComment() helper) and the back end (comment/remove and comment/reply/remove methods).
2.  Added the new isModerator() function to commentsSingleComment.js isOwnComment() helper
3.  Added the new isModerator() function in comment/remove and comment/reply/remove methods in lib/collections/methods/comments.js
4.  Fixed a small css bug with the comment avatar that was causing avatars to be too large in FireFox.
